### PR TITLE
Rename table

### DIFF
--- a/backend/routes/stocks.ts
+++ b/backend/routes/stocks.ts
@@ -44,7 +44,7 @@ router.get('/:symbol', async (req: Request<{ symbol: string }>, res: Response) =
 
   try {
     const { data: cached, error: cacheError } = await supabase
-      .from('price_cache')
+      .from('stock_price_cache')
       .select('*')
       .eq('symbol', symbol)
       .single()
@@ -106,7 +106,7 @@ router.get('/:symbol', async (req: Request<{ symbol: string }>, res: Response) =
     }
 
     const { error: upsertError } = await supabase
-      .from('price_cache')
+      .from('stock_price_cache')
       .upsert(
         {
           symbol,

--- a/backend/routes/symbols.ts
+++ b/backend/routes/symbols.ts
@@ -30,7 +30,7 @@ function isCatalogStale(fetchedAt: string | null) {
 router.get('/stocks', async (_req, res) => {
   try {
     const { data: probe, error: probeError } = await supabase
-      .from('alphavantage_listings')
+      .from('stock_alphavantage_listings')
       .select('fetched_at')
       .order('fetched_at', { ascending: false })
       .limit(1)
@@ -45,7 +45,7 @@ router.get('/stocks', async (_req, res) => {
       console.log('[CATALOG HIT]')
 
       const { data: rows, error: readError } = await supabase
-        .from('alphavantage_listings')
+        .from('stock_alphavantage_listings')
         .select('symbol, name, exchange, asset_type, status')
 
       if (readError) {


### PR DESCRIPTION
Small changes to Supabase table names.

To make table management easier some tables will be separated by classes.
Names of those tables will start with the name of the class.
For example: 'stock_price_cache' or 'stock_alphavantage_listings'